### PR TITLE
실습시간에 커밋테스트, 소스트리 오류로 시간이 조금 지연됨.

### DIFF
--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,2 @@
+2019.11.7
+SourceTree Commit Test


### PR DESCRIPTION
실습시간동안에 올리고싶었지만 소소트리가 계속해서 오류가 났다.
오류의 원인을 다음 수업시간 전까지 찾아서 조정하자.